### PR TITLE
Faster page loads

### DIFF
--- a/assets/components/header.styl
+++ b/assets/components/header.styl
@@ -72,6 +72,7 @@
 
   .hero
     min-height: 220px
+    height: 200px
 
     nav
       width: 110px
@@ -116,6 +117,7 @@
 
   .hero
     min-height: 300px
+    height: 200px
 
     .hero-headline
       width: 520px
@@ -126,6 +128,7 @@
 
   .hero
     min-height: 370px
+    height: 300px
 
     .hero-headline
       width: 772px

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,9 +82,9 @@ function buildJson() {
 }
 
 function buildStatic() {
-  return gulp.src('./assets/**/*')
+  return gulp.src('./assets/images/**/*')
     .pipe(imagemin())
-    .pipe(gulp.dest('build'));
+    .pipe(gulp.dest('build/images'));
 }
 
 function buildStylus() {
@@ -162,7 +162,7 @@ gulp.task('build', ['build-stylus', 'build-static', 'build-json', 'build-templat
 });
 
 gulp.task('deploy', ['build'], function () {
-  return gulp.src("./build/**/*")
+  return gulp.src(["./build/**/*", "!./build/data/**/*"])
     .pipe(deploy({
       cacheDir: './tmp'
     }));

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prebuild": "npm run clean",
     "build": "gulp build",
     "clean": "rimraf ./build",
+    "predeploy": "npm run build",
     "deploy": "gulp deploy",
     "gulp": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -32,6 +33,7 @@
     "gulp-data": "^1.2.1",
     "gulp-gh-pages": "^0.5.4",
     "gulp-imagemin": "^3.0.1",
+    "gulp-inline-source": "^2.1.0",
     "gulp-jade": "^1.1.0",
     "gulp-merge-json": "^0.6.0",
     "gulp-minify-css": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "prebuild": "npm run clean",
     "build": "gulp build",
     "clean": "rimraf ./build",
-    "predeploy": "build",
     "deploy": "gulp deploy",
     "gulp": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/views/templates/index.jade
+++ b/src/views/templates/index.jade
@@ -53,15 +53,21 @@ html
         meta(http-equiv='X-UA-Compatible', content='IE=edge')
         meta(name='viewport', content='width=device-width, initial-scale=1')
         title Hollywood Age Gap
+        link(rel='dns-prefetch', href='https://use.typekit.net')
+        link(rel='dns-prefetch', href='https://www.google-analytics.com')
+        link(rel='dns-prefetch', href='https://platform.twitter.com')
+        link(rel='dns-prefetch', href='https://p.typekit.net')
+        link(rel='dns-prefetch', href='https://ping.typekit.net')
         meta(name='description', content='The age difference in years between movie love interests.')
 
         meta(property='og:site_name', content='Hollywood Age Gap')
         meta(property='og:url', content='http://hollywoodagegap.com')
         meta(property='og:description', content='The age difference in years between movie love interests.')
-        meta(property='og:image', content='http://hollywoodagegap.com/images/facebook-hollywood-age-gap.png')
+        meta(property='og:image', content='http://hollywoodagegap.com/facebook-hollywood-age-gap.png')
         meta(property='og:type', content='website')
 
-        link(rel='stylesheet', href='/app.css')
+        // inline build/app.css
+        link(rel='stylesheet', href='/app.css', inline)
         script.
             (function(d) {
                 var config = {
@@ -82,7 +88,9 @@ html
                 include ../../src/views/templates/ContributeItemView.jade
         .contribute.overlay.hidden
             include ../../src/views/templates/ContributeView.jade
-        script(src='app.js', async)
+
+        // inline build/app.js
+        script(src='app.js', inline)
 
         script.
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
I made this a separate PR in case you don't want it.

This branch does a couple things:

1. DNS prefetching for slightly faster initial calls to twitter/typekit/GA
2. Embeds SVG into CSS so no separate SVG files
3. Embeds CSS and JS into the page so no separate requests for them

The page ends up being 9kb heavier after gzip (62 vs 53)