### PR TITLE
change man icon shape to not only differentiate by color

### DIFF
--- a/assets/components/card.styl
+++ b/assets/components/card.styl
@@ -109,6 +109,7 @@
         background: $marker-pink
       &.man
         background: $marker-blue
+        border-radius: 0%
 
   .actor
     margin-bottom: 6px
@@ -137,6 +138,7 @@
     &.man .age
       color: $marker-blue
       border-color: $marker-blue
+      border-radius: 0%
 
 .social-container
   position: absolute


### PR DESCRIPTION
For a person with a color deficiency (or on a color deficient screen, i.e. grayscale), the "man" and "woman" icons look the same. Making the "man" icons squares instead of circles helps with that.

[WCAG 1.4.1 Use of Color](https://www.w3.org/TR/WCAG21/#use-of-color)