### PR TITLE
Revised Venus data.

### DIFF
--- a/data/movies/venus_2006.json
+++ b/data/movies/venus_2006.json
@@ -1,6 +1,6 @@
 {
   "name": "Venus",
   "year": 2006,
-  "director": "Michael Curtiz",
+  "director": "Roger Michell",
   "relationships": [["Peter O'Toole", "Jodie Whittaker"]]
 }


### PR DESCRIPTION
Michael Curtiz was born 120 years before Venus was released! Talk about an age difference.