### PR TITLE
Add title attributes to show exact birthdates on hover

### DIFF
--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -17,7 +17,7 @@ h2
   each actor in movie.relationship
     .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
 each actor in movie.relationship
-  .actor(class=actor.gender, data-birthday=actor.birthDate, title='Birthday: ' + new Date(actor.birthDate).toLocaleDateString())
+  .actor(class=actor.gender, title='Birthday: ' + new Date(actor.birthDate).toDateString())
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender

--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -17,7 +17,7 @@ h2
   each actor in movie.relationship
     .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
 each actor in movie.relationship
-  .actor(class=actor.gender)(title='Born ' + actor.birthDate)
+  .actor(class=actor.gender, title='Birthday: ' + new Date(actor.birthDate).toLocaleDateString())
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender

--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -17,7 +17,7 @@ h2
   each actor in movie.relationship
     .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
 each actor in movie.relationship
-  .actor(class=actor.gender, title='Birthday: ' + new Date(actor.birthDate).toLocaleDateString())
+  .actor(class=actor.gender, data-birthday=actor.birthDate, title='Birthday: ' + new Date(actor.birthDate).toLocaleDateString())
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender

--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -1,3 +1,4 @@
+- var dateStringOptions = { month: "long", day: "numeric", year: "numeric", };
 - var years = movie.difference === 1 ? 'year' : 'years';
 - var tmdbUrl = 'https://www.themoviedb.org/search/movie?query=' + encodeURIComponent(movie.name);
 h2
@@ -17,7 +18,7 @@ h2
   each actor in movie.relationship
     .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
 each actor in movie.relationship
-  .actor(class=actor.gender, title='Birthday: ' + new Date(actor.birthDate).toDateString())
+  .actor(class=actor.gender, data-birthday=new Date(actor.birthDate).toLocaleDateString(undefined, dateStringOptions), title='Birthday: ' + new Date(actor.birthDate).toDateString())
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender

--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -17,7 +17,7 @@ h2
   each actor in movie.relationship
     .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
 each actor in movie.relationship
-  .actor(class=actor.gender)
+  .actor(class=actor.gender)(title='Born ' + actor.birthDate)
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender

--- a/src/views/templates/MovieView.pug
+++ b/src/views/templates/MovieView.pug
@@ -16,9 +16,9 @@ h2
   span
   span
   each actor in movie.relationship
-    .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%')
+    .marker(class=actor.gender, style='left: ' + Math.round((actor.age - 18) * 1.6129) + '%', title=actor.name + ', born: ' + new Date(actor.birthDate).toDateString())
 each actor in movie.relationship
-  .actor(class=actor.gender, data-birthday=new Date(actor.birthDate).toLocaleDateString(undefined, dateStringOptions), title='Birthday: ' + new Date(actor.birthDate).toDateString())
+  .actor(class=actor.gender, title='Birthday: ' + new Date(actor.birthDate).toDateString())
     .age= actor.age
     .name= actor.name
       span(class='sr-only')=', '+ actor.gender


### PR DESCRIPTION
This makes it so you can hover over a person's name or marker and see their exact birthday: 
<img width="389" height="333" alt="CleanShot 2025-07-11 at 12 09 20" src="https://github.com/user-attachments/assets/8d40d57e-6c66-4532-862c-562c6e27452d" />
<img width="392" height="343" alt="CleanShot 2025-07-11 at 12 10 00" src="https://github.com/user-attachments/assets/9c582be4-afbc-49cf-b75f-3f900f542155" />


This isn't ideal for accessibility or touch devices, but the information otherwise isn't there for anyone?